### PR TITLE
feat: add openai/gpt-5 model to openrouter provider

### DIFF
--- a/source/models/openrouter-provider.ts
+++ b/source/models/openrouter-provider.ts
@@ -29,6 +29,7 @@ const openrouterModels = {
   "qwen3-coder": openRouterClient("qwen/qwen3-coder"),
   "qwen3-coder-free": openRouterClient("qwen/qwen3-coder:free"),
   "glm-4.5": openRouterClient("z-ai/glm-4.5"),
+  "gpt-5": openRouterClient("openai/gpt-5"),
 } as const;
 
 type ModelName = `openrouter:${keyof typeof openrouterModels}`;
@@ -228,5 +229,18 @@ export const openrouterModelRegistry: {
     costPerInputToken: 0.0000006,
     costPerOutputToken: 0.0000022,
     category: "balanced",
+  },
+  "openrouter:gpt-5": {
+    id: "openrouter:gpt-5",
+    provider: "openrouter",
+    contextWindow: 400000,
+    maxOutputTokens: 128000,
+    defaultTemperature: 0.3,
+    promptFormat: "markdown",
+    supportsReasoning: true,
+    supportsToolCalling: true,
+    costPerInputToken: 0.00000125,
+    costPerOutputToken: 0.00001,
+    category: "powerful",
   },
 };


### PR DESCRIPTION
## Summary
- Add OpenAI's GPT-5 model to the OpenRouter provider
- Model features 400k context window and 128k max output tokens
- Supports reasoning and tool calling capabilities
- Pricing: $0.00000125 input tokens, $0.00001 output tokens
- Category: powerful

## Changes
- Added  to  object
- Added comprehensive metadata to 
- Model ID: 
- Available as: 

## Technical Details
- Context Window: 400,000 tokens
- Max Output Tokens: 128,000 tokens
- Default Temperature: 0.3
- Supports Reasoning: true
- Supports Tool Calling: true
- Prompt Format: markdown

The model information was fetched directly from OpenRouter's API to ensure accuracy.