### PR TITLE
feat(grep): add literal option and auto-fallback to fixed-string for unbalanced regexes

### DIFF
--- a/source/tools/grep.ts
+++ b/source/tools/grep.ts
@@ -84,7 +84,9 @@ export const createGrepTool = (
                 sendData?.({
                   event: "tool-update",
                   id: toolCallId,
-                  data: "Pattern appears to contain unbalanced regex metacharacters; using fixed-string mode (-F).",
+                  data: {
+                    primary: "Pattern appears to contain unbalanced regex metacharacters; using fixed-string mode (-F).",
+                  },
                 });
               } else {
                 effectiveLiteral = false;

--- a/source/tools/grep.ts
+++ b/source/tools/grep.ts
@@ -85,7 +85,8 @@ export const createGrepTool = (
                   event: "tool-update",
                   id: toolCallId,
                   data: {
-                    primary: "Pattern appears to contain unbalanced regex metacharacters; using fixed-string mode (-F).",
+                    primary:
+                      "Pattern appears to contain unbalanced regex metacharacters; using fixed-string mode (-F).",
                   },
                 });
               } else {

--- a/test/tools/grep.test.ts
+++ b/test/tools/grep.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildGrepCommand } from "../../source/tools/grep.ts";
+
+test("buildGrepCommand uses -F when literal=true", () => {
+  const cmd = buildGrepCommand("terminal.table(", "/repo", { literal: true });
+  assert.ok(cmd.includes(" -F"));
+});
+
+test("buildGrepCommand does not use -F when literal=false", () => {
+  const cmd = buildGrepCommand("\\w+", "/repo", { literal: false });
+  assert.ok(!cmd.includes(" -F"));
+});
+
+test("buildGrepCommand auto-detects unbalanced pattern and uses -F when literal omitted", () => {
+  const cmd = buildGrepCommand("terminal.table(", "/repo", { literal: null });
+  assert.ok(cmd.includes(" -F"));
+});


### PR DESCRIPTION
Summary:
- Add 'literal?: boolean | null' option to grep tool input schema.
- Auto-detect unbalanced regex grouping characters and fall back to ripgrep -F (fixed string) when literal is omitted.
- Export buildGrepCommand() to allow deterministic unit tests without mocking execSync.
- Add unit tests covering literal=true, literal=false, and auto-fallback behavior.

Details:
- Heuristic detects unbalanced (), [], {} while respecting backslash escapes.
- Emits a tool-update message when auto-fallback occurs (MessageData shape).
- No behavioral change when literal is explicitly set; fallback only happens when omitted/null.

Tests:
- Added test/tools/grep.test.ts. All tests pass locally.

Notes:
- Does not add PCRE (-P) support. Can add pcre?: boolean if needed.