### PR TITLE
feat(bash): skip command preview when auto-approval is enabled

### DIFF
--- a/source/tools/bash.ts
+++ b/source/tools/bash.ts
@@ -269,13 +269,13 @@ export const createBashTool = ({
         if (terminal) {
           if (!autoAcceptCommands) {
             await new Promise((resolve) => setTimeout(resolve, 1000));
+            terminal.lineBreak();
+            terminal.writeln(
+              `${chalk.blue.bold("●")} About to execute command: ${chalk.cyan(originalCommand)}`,
+            );
+            terminal.writeln(`${chalk.gray("Working directory:")} ${safeCwd}`);
+            terminal.lineBreak();
           }
-          terminal.lineBreak();
-          terminal.writeln(
-            `${chalk.blue.bold("●")} About to execute command: ${chalk.cyan(originalCommand)}`,
-          );
-          terminal.writeln(`${chalk.gray("Working directory:")} ${safeCwd}`);
-          terminal.lineBreak();
 
           let userChoice: string;
           if (autoAcceptCommands) {


### PR DESCRIPTION
When the auto-approval flag is true, the bash tool should not show the 'About to execute command' message. This change moves that message inside the condition that checks if auto-approval is disabled, improving the user experience by reducing unnecessary output when auto-approval is enabled.

### Changes Made
- Move 'About to execute command' message inside the  condition
- When  is true, only show the auto-accept confirmation message
- Skip the command preview and working directory display when auto-approval is enabled

### Testing
- Verified that the change works correctly when auto-approval is enabled
- Confirmed that the full command preview still shows when auto-approval is disabled
- All existing tests pass