### PR TITLE
fix(security): disable shell exec; add quote-aware argv tokenizer; harden validation

### DIFF
--- a/source/mentions.ts
+++ b/source/mentions.ts
@@ -107,7 +107,7 @@ async function processFileCommand(context: CommandContext): Promise<string> {
 async function processShellCommand(command: string): Promise<string> {
   try {
     const { stdout, stderr, code } = await executeCommand(command, {
-      shell: true,
+      shell: false,
     });
     if (code === 0) {
       return stdout;

--- a/source/prompts.ts
+++ b/source/prompts.ts
@@ -88,10 +88,12 @@ function toolUsage() {
 - Outline multi-step tasks before execution
 
 ### Bash Commands (\`${BashTool.name}\`)
-- Execute bash commands within project directory only
-- Always specify absolute paths to avoid errors
-- You have access to the Github CLI
-- Try to avoid shell commands that are likely to require user interaction (e.g. \`git rebase -i\`). Use non-interactive versions of commands (e.g. \`npm init -y\` instead of \`npm init\`) when available, and otherwise remind the user that interactive shell commands are not supported and may cause hangs until canceled by the user.
+- Shell is disabled. Do NOT use: |, >, >>, <, <<, ;, &&, ||, &, \`...\`, $().
+- Run a single allowed command with quoted args; no command substitution or chaining.
+- Compose multi-step flows via multiple tool calls or program flags (rg, jq, grep options, etc.).
+- For large gh/git messages, prefer --message-file instead of inlining big strings.
+- Commands execute only within the project directory; always use absolute paths.
+- Avoid interactive commands; prefer non-interactive flags (e.g., npm init -y).
 
 ### Code Interpreter (\`${CodeInterpreterTool.name}\`)
 - Executes JavaScript code in a separate Node.js process using Node's Permission Model

--- a/source/tools/bash.ts
+++ b/source/tools/bash.ts
@@ -269,7 +269,7 @@ export const createBashTool = ({
           const result = await executeCommand(command, {
             cwd: safeCwd,
             timeout: safeTimeout,
-            shell: true,
+            shell: false,
             throwOnError: false,
           });
 

--- a/source/tools/bash.ts
+++ b/source/tools/bash.ts
@@ -147,7 +147,7 @@ export const createBashTool = ({
 
   return {
     [BashTool.name]: tool({
-      description: `Execute bash commands and return their output. Limited to a whitelist of safe commands: ${ALLOWED_COMMANDS.join(", ")}. Commands will only execute within the project directory for security. Always specify absolute paths to avoid errors.`,
+      description: `Execute commands without a shell. Restrictions: no pipes (|), redirects (>, >>, <, <<), chaining (&&, ||, ;), background (&), or command substitution (\`...\`, $()). Pass a single allowed base command with quoted args. Compose by running multiple tool calls or using program flags (e.g., rg, jq). Commands execute only within the project directory. Always use absolute paths. Allowed commands: ${ALLOWED_COMMANDS.join(", ")}.`,
       inputSchema: z.object({
         command: z.string().describe("Full CLI command to execute."),
         cwd: z

--- a/source/tools/command-validation.ts
+++ b/source/tools/command-validation.ts
@@ -4,12 +4,14 @@ export class CommandValidation {
 
   constructor(allowedCommands: string[]) {
     this.allowedCommands = allowedCommands;
-    // Only block truly dangerous patterns, not useful shell operations
+    // Block shell operators and substitutions outright
     this.dangerousPatterns = [
       /`/, // backticks (command substitution)
       /\$\(/, // $() command substitution
-      /&&\s*rm\s+-rf/, // dangerous rm chains
-      /;\s*rm\s+-rf/, // dangerous rm chains
+      /\|/, // pipes
+      />|>>|<|<</, // redirects
+      /;|&&|\|\||&/, // chaining and backgrounding
+      /[\r\n]/, // newlines
     ];
   }
 
@@ -19,13 +21,8 @@ export class CommandValidation {
   }
 
   private hasDangerousPatterns(command: string): boolean {
-    // Remove all quoted segments first
-    const stripped = command
-      .replace(/'([^'\\]|\\.)*'/g, "")
-      .replace(/"([^"\\]|\\.)*"/g, "");
-
-    // Check for dangerous patterns only in unquoted portions
-    return this.dangerousPatterns.some((re) => re.test(stripped));
+    // Do not strip quotes; reject if any dangerous pattern appears anywhere
+    return this.dangerousPatterns.some((re) => re.test(command));
   }
 
   isValid(command: string): { isValid: boolean; error?: string } {
@@ -33,97 +30,24 @@ export class CommandValidation {
       return { isValid: false, error: "Command cannot be empty" };
     }
 
-    // First check for dangerous patterns
     if (this.hasDangerousPatterns(command)) {
       return {
         isValid: false,
         error:
-          "Command contains dangerous patterns (command substitution or unsafe rm chains)",
+          "Pipes, redirects, command substitution, chaining, and newlines are disabled for security.",
       };
     }
 
-    // Process command while preserving quoted strings to extract sub-commands
-    const subCommands: string[] = [];
-    let currentSegment = "";
-    let inSingleQuote = false;
-    let inDoubleQuote = false;
-
-    for (let i = 0; i < command.length; i++) {
-      const char = command[i];
-
-      // Handle quote states
-      if (char === "'" && !inDoubleQuote) inSingleQuote = !inSingleQuote;
-      if (char === '"' && !inSingleQuote) inDoubleQuote = !inDoubleQuote;
-
-      // Split on command separators only when not in quotes
-      // Note: We allow pipes (|) and redirects (>, <) but split on command separators
-      if (!inSingleQuote && !inDoubleQuote && (char === "&" || char === ";")) {
-        if (currentSegment.trim()) {
-          subCommands.push(currentSegment.trim());
-          currentSegment = "";
-        }
-        // Skip the operator and any subsequent same operators (like &&)
-        while (
-          i + 1 < command.length &&
-          ["&", ";"].includes(command[i + 1] ?? "")
-        ) {
-          i++;
-        }
-      } else {
-        currentSegment += char;
-      }
-    }
-
-    // Add the last segment
-    if (currentSegment.trim()) {
-      subCommands.push(currentSegment.trim());
-    }
-
-    // Validate all sub-commands (but be smart about pipes)
-    for (const subCmd of subCommands) {
-      // For piped commands, validate each part of the pipe
-      const pipeParts = this.splitOnPipes(subCmd);
-      for (const part of pipeParts) {
-        const trimmedPart = part.trim();
-        if (trimmedPart && !this.isCommandAllowed(trimmedPart)) {
-          const baseCmd = trimmedPart.split(" ")[0] || "";
-          return {
-            isValid: false,
-            error: `Command '${baseCmd}' is not allowed. Allowed commands: ${this.allowedCommands.join(", ")}`,
-          };
-        }
-      }
+    // No pipes to split now; validate the single command only
+    const trimmed = command.trim();
+    if (!this.isCommandAllowed(trimmed)) {
+      const baseCmd = trimmed.split(" ")[0] || "";
+      return {
+        isValid: false,
+        error: `Command '${baseCmd}' is not allowed. Allowed commands: ${this.allowedCommands.join(", ")}`,
+      };
     }
 
     return { isValid: true };
-  }
-
-  private splitOnPipes(command: string): string[] {
-    const parts: string[] = [];
-    let current = "";
-    let inSingleQuote = false;
-    let inDoubleQuote = false;
-
-    for (let i = 0; i < command.length; i++) {
-      const char = command[i];
-
-      if (char === "'" && !inDoubleQuote) inSingleQuote = !inSingleQuote;
-      if (char === '"' && !inSingleQuote) inDoubleQuote = !inDoubleQuote;
-
-      if (char === "|" && !inSingleQuote && !inDoubleQuote) {
-        if (current.trim()) {
-          parts.push(current.trim());
-          current = "";
-        }
-      } else {
-        current += char;
-      }
-    }
-
-    if (current.trim()) {
-      parts.push(current.trim());
-    }
-
-    return parts;
   }
 }

--- a/source/utils/process.ts
+++ b/source/utils/process.ts
@@ -33,6 +33,88 @@ export interface ExecuteResult {
   signal?: NodeJS.Signals;
 }
 
+export type ParseResult =
+  | { ok: true; argv: [string, ...string[]] }
+  | { ok: false; error: string };
+
+// Quote/escape-aware argv tokenizer that forbids command substitution
+export function parseArgv(input: string): ParseResult {
+  const argv: string[] = [];
+  let buf = "";
+  let i = 0;
+  const n = input.length;
+  let inSingle = false;
+  let inDouble = false;
+
+  while (i < n) {
+    const ch = input[i] ?? "";
+
+    // Reject shell-only constructs early
+    if (ch === "`") return { ok: false, error: "Backticks are not allowed" };
+    if (ch === "$" && i + 1 < n && input[i + 1] === "(") {
+      return { ok: false, error: "Command substitution $() is not allowed" };
+    }
+
+    if (!inSingle && !inDouble && /\s/.test(ch)) {
+      if (buf.length > 0) {
+        argv.push(buf);
+        buf = "";
+      }
+      i += 1;
+      continue;
+    }
+
+    if (!inDouble && ch === "'" && !inSingle) {
+      inSingle = true;
+      i += 1;
+      continue;
+    }
+    if (inSingle && ch === "'") {
+      inSingle = false;
+      i += 1;
+      continue;
+    }
+
+    if (!inSingle && ch === '"' && !inDouble) {
+      inDouble = true;
+      i += 1;
+      continue;
+    }
+    if (inDouble && ch === '"') {
+      inDouble = false;
+      i += 1;
+      continue;
+    }
+
+    if (!inSingle && ch === "\\") {
+      i += 1;
+      if (i >= n) return { ok: false, error: "Dangling escape" };
+      const next = input[i] ?? "";
+      // Inside double quotes, only escape " and \\ reliably
+      if (inDouble && next !== '"' && next !== "\\") {
+        // Keep backslash literally for safety
+        buf += `\\${next}`;
+      } else {
+        buf += next;
+      }
+      i += 1;
+      continue;
+    }
+
+    buf += ch;
+    i += 1;
+  }
+
+  if (inSingle || inDouble) return { ok: false, error: "Unterminated quote" };
+  if (buf.length > 0) argv.push(buf);
+  if (argv.length === 0) return { ok: false, error: "Empty command" };
+  const first = argv[0];
+  if (typeof first !== "string" || first.trim() === "") {
+    return { ok: false, error: "Missing command" };
+  }
+  return { ok: true, argv: argv as [string, ...string[]] };
+}
+
 /**
  * Executes a command and returns the result, providing unified error handling
  *
@@ -61,9 +143,18 @@ export function executeCommand(
   if (Array.isArray(command)) {
     [cmd, ...args] = command;
   } else {
-    const parts = command.split(" ");
-    cmd = parts[0] ?? "";
-    args = parts.slice(1);
+    const parsed = parseArgv(command);
+    if (!parsed.ok) {
+      const result: ExecuteResult = {
+        stdout: "",
+        stderr: parsed.error,
+        code: 1,
+      };
+      return throwOnError
+        ? Promise.reject(new Error(parsed.error))
+        : Promise.resolve(result);
+    }
+    [cmd, ...args] = parsed.argv;
   }
 
   if (isUndefined(cmd) || cmd.trim() === "") {

--- a/test/tools/command-validation.test.ts
+++ b/test/tools/command-validation.test.ts
@@ -7,45 +7,61 @@ describe("CommandValidation", () => {
   const validator = new CommandValidation(allowedCommands);
 
   describe("Valid Commands", () => {
-    it("allows ls && pwd", () => {
-      const result = validator.isValid("ls && pwd");
+    it("allows simple allowed command", () => {
+      const result = validator.isValid("ls -la");
       assert.strictEqual(result.isValid, true);
     });
 
-    it("allows echo 'hi' || ls", () => {
-      const result = validator.isValid("echo 'hi' || ls");
-      assert.strictEqual(result.isValid, true);
-    });
-
-    it("allows ls; pwd", () => {
-      const result = validator.isValid("ls; pwd");
-      assert.strictEqual(result.isValid, true);
-    });
-
-    it("allows ls | grep .ts", () => {
-      const result = validator.isValid("ls | grep .ts");
-      assert.strictEqual(result.isValid, true);
-    });
-
-    it("allows sleep 1 &", () => {
-      const result = validator.isValid("sleep 1 &");
+    it("allows quoted args", () => {
+      const result = validator.isValid('echo "hello world"');
       assert.strictEqual(result.isValid, true);
     });
   });
 
   describe("Invalid Commands", () => {
-    it("allows ls > file (redirects are now permitted)", () => {
+    it("blocks chaining with &&", () => {
+      const result = validator.isValid("ls && pwd");
+      assert.strictEqual(result.isValid, false);
+      assert.ok(result.error?.includes("disabled for security"));
+    });
+
+    it("blocks OR chaining ||", () => {
+      const result = validator.isValid("echo 'hi' || ls");
+      assert.strictEqual(result.isValid, false);
+      assert.ok(result.error?.includes("disabled for security"));
+    });
+
+    it("blocks ; separators", () => {
+      const result = validator.isValid("ls; pwd");
+      assert.strictEqual(result.isValid, false);
+      assert.ok(result.error?.includes("disabled for security"));
+    });
+
+    it("blocks pipes", () => {
+      const result = validator.isValid("ls | grep .ts");
+      assert.strictEqual(result.isValid, false);
+      assert.ok(result.error?.includes("disabled for security"));
+    });
+
+    it("blocks backgrounding with &", () => {
+      const result = validator.isValid("sleep 1 &");
+      assert.strictEqual(result.isValid, false);
+      assert.ok(result.error?.includes("disabled for security"));
+    });
+
+    it("blocks redirects", () => {
       const result = validator.isValid("ls > file");
-      assert.strictEqual(result.isValid, true);
+      assert.strictEqual(result.isValid, false);
+      assert.ok(result.error?.includes("disabled for security"));
     });
 
     it("blocks echo $(date) (unsafe operator)", () => {
       const result = validator.isValid("echo $(date)");
       assert.strictEqual(result.isValid, false);
-      assert.ok(result.error?.includes("dangerous patterns"));
+      assert.ok(result.error?.includes("disabled for security"));
     });
 
-    it("blocks rm -rf / (disallowed command)", () => {
+    it("blocks disallowed command", () => {
       const result = validator.isValid("rm -rf /");
       assert.strictEqual(result.isValid, false);
       assert.ok(result.error?.includes("not allowed"));

--- a/test/utils/process.test.ts
+++ b/test/utils/process.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseArgv } from "../../source/utils/process.ts";
+
+describe("parseArgv", () => {
+  it("parses simple command", () => {
+    const res = parseArgv("echo hi");
+    assert.deepEqual(res, { ok: true, argv: ["echo", "hi"] });
+  });
+
+  it("preserves spaces in double quotes", () => {
+    const res = parseArgv('echo "a b"');
+    assert.equal(res.ok, true);
+    if (res.ok) {
+      assert.deepEqual(res.argv, ["echo", "a b"]);
+    }
+  });
+
+  it("preserves spaces in single quotes (content only)", () => {
+    const res = parseArgv("echo 'a b'");
+    assert.equal(res.ok, true);
+    if (res.ok) {
+      assert.deepEqual(res.argv, ["echo", "a b"]);
+    }
+  });
+
+  it("handles escapes outside quotes", () => {
+    const res = parseArgv("echo a\\ b");
+    assert.equal(res.ok, true);
+    if (res.ok) {
+      assert.deepEqual(res.argv, ["echo", "a b"]);
+    }
+  });
+
+  it("rejects backticks", () => {
+    const res = parseArgv("echo `whoami`");
+    assert.equal(res.ok, false);
+  });
+
+  it("rejects $()", () => {
+    const res = parseArgv("echo $(date)");
+    assert.equal(res.ok, false);
+  });
+
+  it("rejects unterminated quotes", () => {
+    const res = parseArgv("echo 'oops");
+    assert.equal(res.ok, false);
+  });
+
+  it("rejects dangling escape", () => {
+    const res = parseArgv("echo foo\\");
+    assert.equal(res.ok, false);
+  });
+});


### PR DESCRIPTION
- Set shell:false in bash tool and mentions executor
- Implement parseArgv to split quotes/escapes safely; reject backticks and dollar-parentheses
- Block pipes, redirects, chaining, backgrounding, and newlines in CommandValidation
- Preserve single-string tool API; add unit tests for validator and tokenizer
