### PR TITLE
"feat: add openrouter/sonoma-sky-alpha model"

### DIFF
--- a/source/models/openrouter-provider.ts
+++ b/source/models/openrouter-provider.ts
@@ -38,6 +38,7 @@ const openrouterModels = {
   "gpt-5-mini": openRouterClient("openai/gpt-5-mini"),
   "gpt-oss-120b": openRouterClient("openai/gpt-oss-120b"),
   "grok-code-fast-1": openRouterClient("x-ai/grok-code-fast-1"),
+  "sonoma-sky-alpha": openRouterClient("openrouter/sonoma-sky-alpha"),
 } as const;
 
 type ModelName = `openrouter:${keyof typeof openrouterModels}`;
@@ -354,5 +355,18 @@ export const openrouterModelRegistry: {
     costPerInputToken: 0.00000007256312,
     costPerOutputToken: 0.0000002903936,
     category: "fast",
+  },
+  "openrouter:sonoma-sky-alpha": {
+    id: "openrouter:sonoma-sky-alpha",
+    provider: "openrouter",
+    contextWindow: 2000000,
+    maxOutputTokens: 64000, // Default value as max_completion_tokens was null
+    defaultTemperature: 0.5, // Using standard default
+    promptFormat: "markdown", // Assuming markdown format
+    supportsReasoning: true, // Based on "include_reasoning" in supported_parameters
+    supportsToolCalling: true, // Based on "tool_choice" and "tools" in supported_parameters
+    costPerInputToken: 0, // Free during testing period
+    costPerOutputToken: 0, // Free during testing period
+    category: "powerful", // Given the description as "maximally intelligent"
   },
 };


### PR DESCRIPTION
feat: add openrouter/sonoma-sky-alpha model

- Add sonoma-sky-alpha model to openrouter provider
- Model features 2M token context window and supports image inputs
- Supports reasoning and parallel tool calling
- Free during testing period
- Categorized as powerful model