### PR TITLE
"feat: add openrouter/sonoma-dusk-alpha model to provider"

### DIFF
--- a/source/models/openrouter-provider.ts
+++ b/source/models/openrouter-provider.ts
@@ -39,6 +39,7 @@ const openrouterModels = {
   "gpt-oss-120b": openRouterClient("openai/gpt-oss-120b"),
   "grok-code-fast-1": openRouterClient("x-ai/grok-code-fast-1"),
   "sonoma-sky-alpha": openRouterClient("openrouter/sonoma-sky-alpha"),
+  "sonoma-dusk-alpha": openRouterClient("openrouter/sonoma-dusk-alpha"),
 } as const;
 
 type ModelName = `openrouter:${keyof typeof openrouterModels}`;
@@ -368,5 +369,18 @@ export const openrouterModelRegistry: {
     costPerInputToken: 0, // Free during testing period
     costPerOutputToken: 0, // Free during testing period
     category: "powerful", // Given the description as "maximally intelligent"
+  },
+  "openrouter:sonoma-dusk-alpha": {
+    id: "openrouter:sonoma-dusk-alpha",
+    provider: "openrouter",
+    contextWindow: 2000000,
+    maxOutputTokens: 64000, // Default value as max_completion_tokens was null
+    defaultTemperature: 0.5, // Using standard default
+    promptFormat: "markdown", // Assuming markdown format
+    supportsReasoning: false, // Not explicitly mentioned in supported_parameters
+    supportsToolCalling: true, // Based on "tool_choice" and "tools" in supported_parameters
+    costPerInputToken: 0, // Free during testing period
+    costPerOutputToken: 0, // Free during testing period
+    category: "powerful", // Given the description as "fast and intelligent general-purpose frontier model"
   },
 };


### PR DESCRIPTION
## Summary

This PR adds the new `openrouter/sonoma-dusk-alpha` model to the OpenRouter provider.

## Changes

- Added `sonoma-dusk-alpha` model client to the OpenRouter provider
- Added comprehensive model metadata including:
  - 2 million token context window
  - Tool calling support
  - Free pricing during testing period
  - Configured as a powerful model category

## Model Details

The `openrouter/sonoma-dusk-alpha` model is described as:
- A fast and intelligent general-purpose frontier model
- 2 million token context window
- Supports image inputs and parallel tool calling
- Free to use during testing period
- Prompts and completions are logged by the model creator for feedback and training

## Verification

- ✅ Build succeeds
- ✅ Linting passes
- ✅ All tests pass (114/114)
- ✅ Type checking passes

The model is now available for use in the application as `openrouter:sonoma-dusk-alpha`.