### PR TITLE
feat: add support for groq provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ai-sdk/anthropic": "^2.0.12",
         "@ai-sdk/deepseek": "^1.0.15",
         "@ai-sdk/google": "^2.0.12",
+        "@ai-sdk/groq": "^2.0.17",
         "@ai-sdk/openai": "^2.0.24",
         "@ai-sdk/openai-compatible": "^1.0.15",
         "@crosscopy/clipboard": "^0.2.8",
@@ -109,6 +110,22 @@
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.12.tgz",
       "integrity": "sha512-BH3w0hPddNo82okuF/UmCZreKibUSDTW/SED0sBWlrj16S9/H/Urzf4mBwwT419kVenb8XvO55KJ6Byc8ONNXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4"
+      }
+    },
+    "node_modules/@ai-sdk/groq": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/groq/-/groq-2.0.17.tgz",
+      "integrity": "sha512-Oh6Fk988KNvqy4w1crBhBQU8JIkfqhxSiYCbBZFqZSeDsagZ8SHsS2ni9+7pq6e0DR/XGp6fDGDFsm+01kmsmg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@ai-sdk/anthropic": "^2.0.12",
     "@ai-sdk/deepseek": "^1.0.15",
     "@ai-sdk/google": "^2.0.12",
+    "@ai-sdk/groq": "^2.0.17",
     "@ai-sdk/openai": "^2.0.24",
     "@ai-sdk/openai-compatible": "^1.0.15",
     "@crosscopy/clipboard": "^0.2.8",

--- a/source/models/groq-provider.ts
+++ b/source/models/groq-provider.ts
@@ -1,0 +1,43 @@
+import { createGroq, groq as originalGroq } from "@ai-sdk/groq";
+import { objectKeys } from "@travisennis/stdlib/object";
+import { customProvider } from "ai";
+import type { ModelMetadata } from "./providers.ts";
+
+const groq = createGroq({
+  apiKey: process.env["GROQ_API_KEY"] ?? "",
+});
+
+const groqModels = {
+  "kimi-k2-instruct-0905": groq("moonshotai/kimi-k2-instruct-0905"),
+} as const;
+
+type ModelName = `groq:${keyof typeof groqModels}`;
+
+export const groqModelNames: ModelName[] = objectKeys(groqModels).map(
+  (key) => `groq:${key}` as const,
+);
+
+export const groqProvider = {
+  groq: customProvider({
+    languageModels: groqModels,
+    fallbackProvider: originalGroq,
+  }),
+};
+
+export const groqModelRegistry: {
+  [K in ModelName]: ModelMetadata<ModelName>;
+} = {
+  "groq:kimi-k2-instruct-0905": {
+    id: "groq:kimi-k2-instruct-0905",
+    provider: "groq",
+    contextWindow: 262144,
+    maxOutputTokens: 16384,
+    defaultTemperature: 0.1,
+    promptFormat: "markdown",
+    supportsReasoning: false,
+    supportsToolCalling: true,
+    costPerInputToken: 1 / 1000000,
+    costPerOutputToken: 3 / 1000000,
+    category: "fast",
+  },
+};

--- a/source/models/providers.ts
+++ b/source/models/providers.ts
@@ -17,6 +17,11 @@ import {
   googleProvider,
 } from "./google-provider.ts";
 import {
+  groqModelNames,
+  groqModelRegistry,
+  groqProvider,
+} from "./groq-provider.ts";
+import {
   openaiModelNames,
   openaiModelRegistry,
   openaiProvider,
@@ -36,6 +41,7 @@ export const providers = [
   "anthropic",
   "openai",
   "google",
+  "groq",
   "deepseek",
   "openrouter",
   "xai",
@@ -47,6 +53,7 @@ const registry = createProviderRegistry({
   ...anthropicProvider,
   ...deepseekProvider,
   ...googleProvider,
+  ...groqProvider,
   ...openaiProvider,
   ...openrouterProvider,
   ...xaiProvider,
@@ -56,6 +63,7 @@ export const models = [
   ...anthropicModelNames,
   ...openaiModelNames,
   ...googleModelNames,
+  ...groqModelNames,
   ...deepseekModelNames,
   ...openrouterModelNames,
   ...xaiModelNames,
@@ -67,6 +75,7 @@ export type ModelName =
   | (`openai:${string}` & {})
   | (`anthropic:${string}` & {})
   | (`google:${string}` & {})
+  | (`groq:${string}` & {})
   | (`deepseek:${string}` & {})
   | (`openrouter:${string}` & {});
 
@@ -78,6 +87,7 @@ export function isSupportedModel(model: unknown): model is ModelName {
         model.startsWith("anthropic:") ||
         model.startsWith("openai:") ||
         model.startsWith("google:") ||
+        model.startsWith("groq:") ||
         model.startsWith("xai:") ||
         model.startsWith("deepseek:")))
   );
@@ -108,6 +118,7 @@ export const modelRegistry: Record<ModelName, ModelMetadata> = {
   ...anthropicModelRegistry,
   ...openaiModelRegistry,
   ...googleModelRegistry,
+  ...groqModelRegistry,
   ...deepseekModelRegistry,
   ...openrouterModelRegistry,
   ...xaiModelRegistry,
@@ -124,6 +135,7 @@ export function getModelsByProvider(): Record<ModelProvider, ModelMetadata[]> {
     anthropic: [],
     openai: [],
     google: [],
+    groq: [],
     deepseek: [],
     openrouter: [],
     xai: [],


### PR DESCRIPTION
- Introduces `@ai-sdk/groq` as a new dependency
- Implements `groq-provider.ts` with model registry and provider setup
- Registers Groq models and metadata in the global provider registry
- Adds Groq to supported providers and model type definitions