### PR TITLE
fix: strip outer quotes from command arguments before spawn execution

### DIFF
--- a/source/utils/safe-shell.ts
+++ b/source/utils/safe-shell.ts
@@ -384,6 +384,17 @@ export function validate(
 }
 
 // Execution --------------------------------------------------------------
+// Strip outer quotes from arguments since spawn() doesn't need shell-style quote processing
+function stripOuterQuotes(arg: string): string {
+  if (arg.length >= 2) {
+    const first = arg[0];
+    const last = arg[arg.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return arg.slice(1, -1);
+    }
+  }
+  return arg;
+}
 
 export interface ExecOptions {
   cwd: string;
@@ -440,8 +451,10 @@ export async function execute(
     for (let j = 0; j < pipe.commands.length; j++) {
       const cmd = pipe.commands[j] as CommandNode;
       const [exe, ...args] = cmd.argv;
+      // Strip outer quotes from arguments since spawn() doesn't process shell quotes
+      const strippedArgs = args.map(stripOuterQuotes);
       const stdio: ("pipe" | "ignore")[] = ["pipe", "pipe", "pipe"];
-      const p = spawn(exe, args, {
+      const p = spawn(exe, strippedArgs, {
         cwd: opts.cwd,
         stdio,
         signal: opts.abortSignal,


### PR DESCRIPTION
## Summary
Fixes the issue where commit messages and PR titles were wrapped in quotes when using the bash tool.

## Problem
The bash tool was preserving quotes in tokenized arguments, but when these tokens were passed to Node.js `spawn()`, the quotes were treated as literal characters rather than shell quote delimiters. This resulted in git commits and GitHub PR creations having unwanted quotes in their titles and messages.

For example:
- `git commit -m "message"` would create a commit with the message `"message"` (including quotes)
- `gh pr create --title "Title"` would create a PR with the title `"Title"` (including quotes)

## Root Cause
The safe-shell tokenizer correctly preserves quotes during parsing for shell-like syntax handling. However, the execution via `spawn()` doesn't provide shell-like quote processing, causing quoted arguments to be passed literally to commands.

## Solution
Added a `stripOuterQuotes()` function that removes outer quotes from arguments before passing them to `spawn()`. The function:

1. Checks if the argument has at least 2 characters
2. Verifies if the first and last characters are matching quotes (`"` or `'`)
3. If so, strips them using `slice(1, -1)`
4. Otherwise returns the argument unchanged

The fix is applied in the `execute()` function where `args.map(stripOuterQuotes)` is called before passing arguments to `spawn()`.

## Changes
- **Modified**: `source/utils/safe-shell.ts`
  - Added `stripOuterQuotes()` helper function
  - Modified spawn call to use stripped arguments

## Testing
- All existing tests pass ✅
- No regression in functionality ✅
- Build succeeds ✅
- Maintains backward compatibility ✅

## Impact
- Git commit messages no longer include literal quotes
- GitHub PR titles and messages no longer include literal quotes
- All other bash functionality remains unchanged
- No breaking changes to existing API

This fix addresses the core issue while maintaining all existing security and functionality constraints of the bash tool.