### PR TITLE
fix(tools): correct path validation and directory tree output

### DIFF
--- a/source/tools/directory-tree.ts
+++ b/source/tools/directory-tree.ts
@@ -75,10 +75,15 @@ export const createDirectoryTreeTool = async ({
           sendData?.({
             id: toolCallId,
             event: "tool-completion",
-            data: "Done",
+            data: `Done (${managed.tokenCount} tokens)`,
           });
           return managed.content;
         } catch (error) {
+          sendData?.({
+            id: toolCallId,
+            event: "tool-error",
+            data: "Failed to show directory tree.",
+          });
           return `Failed to show directory tree: ${(error as Error).message}`;
         }
       },

--- a/source/tools/filesystem-utils.ts
+++ b/source/tools/filesystem-utils.ts
@@ -40,7 +40,17 @@ export async function validatePath(
     ? path.resolve(expandedPath)
     : path.resolve(process.cwd(), expandedPath);
   const normalizedRequested = normalizePath(absolute);
-  const normalizedAllowed = normalizePath(path.resolve(allowedDirectory));
+  let normalizedAllowed = normalizePath(path.resolve(allowedDirectory));
+  // Try to resolve real path for allowedDirectory when it exists to handle symlinked roots
+  try {
+    const stats = await fs.stat(normalizedAllowed);
+    if (stats.isDirectory()) {
+      const allowedReal = await fs.realpath(normalizedAllowed);
+      normalizedAllowed = normalizePath(allowedReal);
+    }
+  } catch (_err) {
+    // If allowedDirectory doesn't exist, keep normalizedAllowed as-is
+  }
 
   // Helper to check if a path is within the allowed directory using path.relative
   const isWithinAllowed = (targetPath: string): boolean => {
@@ -224,7 +234,7 @@ async function generateDirectoryTree(
   for (let i = 0; i < filteredItems.length; i++) {
     const item = filteredItems[i] ?? "";
     const itemPath = path.join(dirPath, item);
-    const isLast = i === items.length - 1;
+    const isLast = i === filteredItems.length - 1;
     const stats = await fs.stat(itemPath);
 
     if (stats.isDirectory()) {

--- a/source/tools/filesystem-utils.ts
+++ b/source/tools/filesystem-utils.ts
@@ -40,11 +40,13 @@ export async function validatePath(
     ? path.resolve(expandedPath)
     : path.resolve(process.cwd(), expandedPath);
   const normalizedRequested = normalizePath(absolute);
+  const normalizedAllowed = normalizePath(path.resolve(allowedDirectory));
 
   // Helper to check if a path is within the allowed directory using path.relative
   const isWithinAllowed = (targetPath: string): boolean => {
-    const rel = path.relative(allowedDirectory, targetPath);
-    return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+    const rel = path.relative(normalizedAllowed, targetPath);
+    // Allow the allowed directory itself (rel === "") and any descendant paths
+    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
   };
 
   // Check intended path is within allowed directory

--- a/test/tools/filesystem-utils.test.ts
+++ b/test/tools/filesystem-utils.test.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { test } from "node:test";
+
+import { validatePath } from "../../source/tools/filesystem-utils.ts";
+
+const projectRoot = process.cwd();
+
+await test("validatePath allows the allowedDirectory itself", async () => {
+  const allowed = projectRoot;
+  const resolved = await validatePath(allowed, allowed);
+  assert.equal(path.resolve(resolved), path.resolve(allowed));
+});
+
+await test("validatePath allows descendants of allowedDirectory", async () => {
+  const allowed = projectRoot;
+  const dir = path.join(allowed, ".acai-ci-tmp-validatePath");
+  const file = path.join(dir, "child.txt");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(file, "ok");
+  const resolved = await validatePath(file, allowed);
+  assert.equal(path.resolve(resolved), path.resolve(file));
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+await test("validatePath rejects paths outside allowedDirectory", async () => {
+  const allowed = path.join(projectRoot, "sub-allowed");
+  await fs.mkdir(allowed, { recursive: true });
+  const outside = path.join(projectRoot, "..", "outside.txt");
+  let threw = false;
+  try {
+    await validatePath(outside, allowed);
+  } catch (_err) {
+    threw = true;
+  }
+  assert.equal(threw, true);
+  await fs.rm(allowed, { recursive: true, force: true });
+});


### PR DESCRIPTION
Fix directoryTree path validation and improve robustness.

Key changes
- tools: validatePath now accepts the base allowed directory and normalizes/realpaths the allowedDirectory when available to handle symlinked roots.
- tools: directory tree generator uses filteredItems.length for isLast, fixing formatting when .gitignore filters entries.
- tools: directoryTree tool now provides clearer completion and error events, and token-aware output.

Why
- Previously, validatePath rejected the allowed directory itself, causing false "Access denied" errors even when the path equaled the project root.
- Path comparisons could fail with trailing-slash and symlink differences.
- Directory tree output could mis-mark last entries when filtering.

Tests
- Added tests for validatePath covering base dir allowed, descendant allowed, and outside rejected.
- All tests pass locally.

Notes
- No changes to repl.ts.
