### PR TITLE
feat(openrouter): add x-ai/grok-4-fast:free; remove deprecated Sonoma models

### DIFF
--- a/source/models/openrouter-provider.ts
+++ b/source/models/openrouter-provider.ts
@@ -39,8 +39,6 @@ const openrouterModels = {
   "gpt-oss-120b": openRouterClient("openai/gpt-oss-120b"),
   "grok-code-fast-1": openRouterClient("x-ai/grok-code-fast-1"),
   "grok-4-fast-free": openRouterClient("x-ai/grok-4-fast:free"),
-  "sonoma-sky-alpha": openRouterClient("openrouter/sonoma-sky-alpha"),
-  "sonoma-dusk-alpha": openRouterClient("openrouter/sonoma-dusk-alpha"),
 } as const;
 
 type ModelName = `openrouter:${keyof typeof openrouterModels}`;
@@ -370,31 +368,5 @@ export const openrouterModelRegistry: {
     costPerInputToken: 0,
     costPerOutputToken: 0,
     category: "fast",
-  },
-  "openrouter:sonoma-sky-alpha": {
-    id: "openrouter:sonoma-sky-alpha",
-    provider: "openrouter",
-    contextWindow: 2000000,
-    maxOutputTokens: 64000, // Default value as max_completion_tokens was null
-    defaultTemperature: 0.5, // Using standard default
-    promptFormat: "markdown", // Assuming markdown format
-    supportsReasoning: true, // Based on "include_reasoning" in supported_parameters
-    supportsToolCalling: true, // Based on "tool_choice" and "tools" in supported_parameters
-    costPerInputToken: 0, // Free during testing period
-    costPerOutputToken: 0, // Free during testing period
-    category: "powerful", // Given the description as "maximally intelligent"
-  },
-  "openrouter:sonoma-dusk-alpha": {
-    id: "openrouter:sonoma-dusk-alpha",
-    provider: "openrouter",
-    contextWindow: 2000000,
-    maxOutputTokens: 64000, // Default value as max_completion_tokens was null
-    defaultTemperature: 0.5, // Using standard default
-    promptFormat: "markdown", // Assuming markdown format
-    supportsReasoning: false, // Not explicitly mentioned in supported_parameters
-    supportsToolCalling: true, // Based on "tool_choice" and "tools" in supported_parameters
-    costPerInputToken: 0, // Free during testing period
-    costPerOutputToken: 0, // Free during testing period
-    category: "powerful", // Given the description as "fast and intelligent general-purpose frontier model"
   },
 };

--- a/source/models/openrouter-provider.ts
+++ b/source/models/openrouter-provider.ts
@@ -38,6 +38,7 @@ const openrouterModels = {
   "gpt-5-mini": openRouterClient("openai/gpt-5-mini"),
   "gpt-oss-120b": openRouterClient("openai/gpt-oss-120b"),
   "grok-code-fast-1": openRouterClient("x-ai/grok-code-fast-1"),
+  "grok-4-fast-free": openRouterClient("x-ai/grok-4-fast:free"),
   "sonoma-sky-alpha": openRouterClient("openrouter/sonoma-sky-alpha"),
   "sonoma-dusk-alpha": openRouterClient("openrouter/sonoma-dusk-alpha"),
 } as const;
@@ -355,6 +356,19 @@ export const openrouterModelRegistry: {
     supportsToolCalling: true,
     costPerInputToken: 0.00000007256312,
     costPerOutputToken: 0.0000002903936,
+    category: "fast",
+  },
+  "openrouter:grok-4-fast-free": {
+    id: "openrouter:grok-4-fast-free",
+    provider: "openrouter",
+    contextWindow: 2000000,
+    maxOutputTokens: 64000,
+    defaultTemperature: 0.5,
+    promptFormat: "markdown",
+    supportsReasoning: true,
+    supportsToolCalling: true,
+    costPerInputToken: 0,
+    costPerOutputToken: 0,
     category: "fast",
   },
   "openrouter:sonoma-sky-alpha": {


### PR DESCRIPTION
This PR adds the new OpenRouter model for xAI Grok 4 Fast (free) and removes deprecated Sonoma alpha models.

Changes
- feat(openrouter): add x-ai/grok-4-fast:free model
- refactor(openrouter): remove deprecated Sonoma alpha models (sonoma-sky-alpha, sonoma-dusk-alpha)

Details
- Pulled model metadata from OpenRouter /api/v1/models
- Registered mapping and metadata (2M ctx, tools+reasoning, free pricing)

Checks
- Lint/format/typecheck/build passed
- All tests passing

Refs
- https://openrouter.ai/api/v1/models